### PR TITLE
Fixes bugs & iterates on nav bar

### DIFF
--- a/ci/app/sign/sign-writing-font-parser.ts
+++ b/ci/app/sign/sign-writing-font-parser.ts
@@ -282,15 +282,15 @@ export class SignWritingFontParser implements DataParser {
             case 80:
                 return {
                     palm_towards: false,
-                    palm_away: false,
-                    palm_sideways: true,
+                    palm_away: true,
+                    palm_sideways: false,
                 };
             case 16:
             case 64:
                 return {
                     palm_towards: false,
-                    palm_away: true,
-                    palm_sideways: false,
+                    palm_away: false,
+                    palm_sideways: true,
                 };
             // 0 or 48
             default:

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -15,23 +15,53 @@ type Props = {
     scrollTop?: boolean,
 };
 
+type EventListener = {
+    type: string,
+    fn,
+}
+
 const TOGGLED_ON_CLASS = "on";
 
 export class MultiSelect extends React.Component<Props> {
     checkboxListId: string;
+    toggleOnClickOutside: EventListener;
+    hideOnEscape: EventListener;
 
     constructor(props) {
         super(props);
         this.checkboxListId = `${this.props.id}-checkbox-list`;
+        this.toggleOnClickOutside = {
+            type: "click",
+            fn: this.maybeHideDropDown.bind(this),
+        };
+        this.hideOnEscape = {
+            type: "keydown",
+            fn: e => {
+                if (e.key == "Escape") {
+                    document.getElementById(this.props.id).classList.remove(TOGGLED_ON_CLASS);
+                }
+            },
+        };
+    }
+
+    addEventListenerToBody(eventListener: EventListener) {
+        const {type, fn} = eventListener;
+        document.body.addEventListener(type, fn);
     }
 
     componentDidMount() {
-        document.body.addEventListener("click", this.maybeHideDropDown.bind(this));
-        document.body.addEventListener('keydown', e => {
-            if (e.key == "Escape") {
-                document.getElementById(this.props.id).classList.remove(TOGGLED_ON_CLASS);
-            }
-        });
+        this.addEventListenerToBody(this.toggleOnClickOutside);
+        this.addEventListenerToBody(this.hideOnEscape);
+    }
+
+    removeEventListenerFromBody(eventListener: EventListener){
+        const {type, fn} = eventListener;
+        document.body.removeEventListener(type, fn);
+    }
+
+    componentWillUnmount() {
+        this.removeEventListenerFromBody(this.toggleOnClickOutside);
+        this.removeEventListenerFromBody(this.hideOnEscape);
     }
 
     maybeHideDropDown(e) {

--- a/src/pages/sign-languages.tsx
+++ b/src/pages/sign-languages.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Option, Select } from '../components/select.tsx';
+import { Toolbar, ToolbarType } from '../components/toolbar.tsx';
 import { KEYBOARD_CONTROL_CLASS, PHONEME_SYMOL_CLASS } from '../constants.ts';
 import { sendQuery } from '../db/ipc.ts';
-import { SignDialect } from '../phonemes/sign/sign-dialect.ts';
 import { Hand } from '../phonemes/sign/hand.ts';
-import { Toolbar, ToolbarButton, ToolbarType } from '../components/toolbar.tsx';
+import { SignDialect } from '../phonemes/sign/sign-dialect.ts';
 import { CLOCKWISE_SIGN_WRITING_SYMBOL_ROTATIONS, SignWritingSymbolRotation } from '../phonemes/sign/sign-writing.ts';
 
 type Props = {};

--- a/src/react-app.tsx
+++ b/src/react-app.tsx
@@ -9,7 +9,7 @@ import { ExportData } from './pages/export-data.tsx';
 const NAV_BAR_ID = "navigation-bar";
 const NAV_BAR_TOGGLE_BUTTON_ID = "navigation-bar-toggle-button";
 
-const hideNavMenu = () => {
+const hideNavMenuIfShown = () => {
     const navBarToggleButton = document.getElementById(NAV_BAR_TOGGLE_BUTTON_ID);
     if (navBarToggleButton.getAttribute("aria-expanded") === "true") {
         navBarToggleButton.click();
@@ -42,7 +42,7 @@ const Navbar = () => {
                             <Link
                                 className="nav-link"
                                 to="/spoken-languages"
-                                onClick={e => hideNavMenu()}
+                                onClick={e => hideNavMenuIfShown()}
                             >
                                 🗣️&nbsp;&nbsp;Spoken Languages
                             </Link>
@@ -51,7 +51,7 @@ const Navbar = () => {
                             <Link
                                 className="nav-link"
                                 to="/sign-languages"
-                                onClick={e => hideNavMenu()}
+                                onClick={e => hideNavMenuIfShown()}
                             >
                                 🤟&nbsp;&nbsp;Sign Languages
                             </Link>
@@ -60,7 +60,7 @@ const Navbar = () => {
                             <Link
                                 className="nav-link"
                                 to="/export-data"
-                                onClick={e => hideNavMenu()}
+                                onClick={e => hideNavMenuIfShown()}
                             >
                                 💾&nbsp;&nbsp;Export Data
                             </Link>
@@ -70,7 +70,7 @@ const Navbar = () => {
                                 className="nav-link"
                                 href="https://mxskylar.github.io/phlexicon"
                                 target="_blank"
-                                onClick={e => hideNavMenu()}
+                                onClick={e => hideNavMenuIfShown()}
                             >
                                 📖&nbsp;&nbsp;User Guide
                             </a>
@@ -90,12 +90,12 @@ class App extends React.Component {
             // If element is not a child of the nav bar
             // and is not the nav bar itself
             if (element !== navBar && !navBar.contains(element)) {
-               hideNavMenu();
+               hideNavMenuIfShown();
             }
         });
         document.body.addEventListener("keydown", e => {
             if (e.key == "Escape") {
-                hideNavMenu();
+                hideNavMenuIfShown();
             }
         });
     }

--- a/src/react-app.tsx
+++ b/src/react-app.tsx
@@ -6,9 +6,10 @@ import { SpokenLanguages } from './pages/spoken-languages.tsx';
 import { SignLanguages } from './pages/sign-languages.tsx';
 import { ExportData } from './pages/export-data.tsx';
 
+const NAV_BAR_ID = "navigation-bar";
 const NAV_BAR_TOGGLE_BUTTON_ID = "navigation-bar-toggle-button";
 
-const hideNavMenu = e => {
+const hideNavMenu = () => {
     const navBarToggleButton = document.getElementById(NAV_BAR_TOGGLE_BUTTON_ID);
     if (navBarToggleButton.getAttribute("aria-expanded") === "true") {
         navBarToggleButton.click();
@@ -17,7 +18,10 @@ const hideNavMenu = e => {
 
 const Navbar = () => {
     return (
-        <nav className="navbar navbar-expand-lg navbar-dark bg-primary mb-2">
+        <nav
+            className="navbar navbar-expand-lg navbar-dark bg-primary mb-2"
+            id={NAV_BAR_ID}
+        >
             <div className="container-fluid">
                 <div className="navbar-brand">Phlexicon</div>
                 <button
@@ -38,7 +42,7 @@ const Navbar = () => {
                             <Link
                                 className="nav-link"
                                 to="/spoken-languages"
-                                onClick={e => hideNavMenu(e)}
+                                onClick={e => hideNavMenu()}
                             >
                                 🗣️&nbsp;&nbsp;Spoken Languages
                             </Link>
@@ -47,7 +51,7 @@ const Navbar = () => {
                             <Link
                                 className="nav-link"
                                 to="/sign-languages"
-                                onClick={e => hideNavMenu(e)}
+                                onClick={e => hideNavMenu()}
                             >
                                 🤟&nbsp;&nbsp;Sign Languages
                             </Link>
@@ -56,7 +60,7 @@ const Navbar = () => {
                             <Link
                                 className="nav-link"
                                 to="/export-data"
-                                onClick={e => hideNavMenu(e)}
+                                onClick={e => hideNavMenu()}
                             >
                                 💾&nbsp;&nbsp;Export Data
                             </Link>
@@ -66,7 +70,7 @@ const Navbar = () => {
                                 className="nav-link"
                                 href="https://mxskylar.github.io/phlexicon"
                                 target="_blank"
-                                onClick={e => hideNavMenu(e)}
+                                onClick={e => hideNavMenu()}
                             >
                                 📖&nbsp;&nbsp;User Guide
                             </a>
@@ -78,18 +82,37 @@ const Navbar = () => {
     );
 }
 
-const App = () => {
-    return (
-        <BrowserRouter>
-            <Navbar/>
-            <Routes>
-                <Route path="/spoken-languages" element={<SpokenLanguages/>}/>
-                <Route path="/sign-languages"  element={<SignLanguages/>}/>
-                <Route path="/export-data"  element={<ExportData/>}/>
-                <Route path="*" element={<Navigate to="/spoken-languages" replace />}/>
-            </Routes>
-        </BrowserRouter>
-    );
+class App extends React.Component {
+    componentDidMount() {
+        document.body.addEventListener("click", e => {
+            const element = e.target as Node;
+            const navBar = document.getElementById(NAV_BAR_ID);
+            // If element is not a child of the nav bar
+            // and is not the nav bar itself
+            if (element !== navBar && !navBar.contains(element)) {
+               hideNavMenu();
+            }
+        });
+        document.body.addEventListener("keydown", e => {
+            if (e.key == "Escape") {
+                hideNavMenu();
+            }
+        });
+    }
+
+    render() {
+        return (
+            <BrowserRouter>
+                <Navbar/>
+                <Routes>
+                    <Route path="/spoken-languages" element={<SpokenLanguages/>}/>
+                    <Route path="/sign-languages"  element={<SignLanguages/>}/>
+                    <Route path="/export-data"  element={<ExportData/>}/>
+                    <Route path="*" element={<Navigate to="/spoken-languages" replace />}/>
+                </Routes>
+            </BrowserRouter>
+        );
+    }
   }
 
 const node = document.getElementById('react-app');

--- a/src/react-app.tsx
+++ b/src/react-app.tsx
@@ -6,27 +6,70 @@ import { SpokenLanguages } from './pages/spoken-languages.tsx';
 import { SignLanguages } from './pages/sign-languages.tsx';
 import { ExportData } from './pages/export-data.tsx';
 
+const NAV_BAR_TOGGLE_BUTTON_ID = "navigation-bar-toggle-button";
+
+const hideNavMenu = e => {
+    const navBarToggleButton = document.getElementById(NAV_BAR_TOGGLE_BUTTON_ID);
+    if (navBarToggleButton.getAttribute("aria-expanded") === "true") {
+        navBarToggleButton.click();
+    }
+}
+
 const Navbar = () => {
     return (
         <nav className="navbar navbar-expand-lg navbar-dark bg-primary mb-2">
             <div className="container-fluid">
                 <div className="navbar-brand">Phlexicon</div>
-                <button className="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <button
+                    className="navbar-toggler"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#navbarNav"
+                    aria-controls="navbarNav"
+                    aria-expanded="false"
+                    aria-label="Toggle navigation"
+                    id={NAV_BAR_TOGGLE_BUTTON_ID}
+                >
                     <span className="navbar-toggler-icon"></span>
                 </button>
                 <div className="collapse navbar-collapse" id="navbarNav">
                     <ul className="navbar-nav">
                         <li className="nav-item">
-                            <Link className="nav-link" to="/spoken-languages">🗣️&nbsp;&nbsp;Spoken Languages</Link>
+                            <Link
+                                className="nav-link"
+                                to="/spoken-languages"
+                                onClick={e => hideNavMenu(e)}
+                            >
+                                🗣️&nbsp;&nbsp;Spoken Languages
+                            </Link>
                         </li>
                         <li className="nav-item">
-                            <Link className="nav-link" to="/sign-languages">🤟&nbsp;&nbsp;Sign Languages</Link>
+                            <Link
+                                className="nav-link"
+                                to="/sign-languages"
+                                onClick={e => hideNavMenu(e)}
+                            >
+                                🤟&nbsp;&nbsp;Sign Languages
+                            </Link>
                         </li>
                         <li className="nav-item">
-                            <Link className="nav-link" to="/export-data">💾&nbsp;&nbsp;Export Data</Link>
+                            <Link
+                                className="nav-link"
+                                to="/export-data"
+                                onClick={e => hideNavMenu(e)}
+                            >
+                                💾&nbsp;&nbsp;Export Data
+                            </Link>
                         </li>
                         <li className="nav-item">
-                            <a className="nav-link" href="https://mxskylar.github.io/phlexicon" target="_blank">📖&nbsp;&nbsp;User Guide</a>
+                            <a
+                                className="nav-link"
+                                href="https://mxskylar.github.io/phlexicon"
+                                target="_blank"
+                                onClick={e => hideNavMenu(e)}
+                            >
+                                📖&nbsp;&nbsp;User Guide
+                            </a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
- Fixes DB bug that inserted incorrect cardinal palm directions into `hands` table
- Fixes bug with invalid event listener when switching pages
- Toggles nav bar closed on escape, when switching pages, and when clicking outside the nav bar